### PR TITLE
video grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Once you have created a token instance, you can add access grant with desired AP
 // grant token access to progammable video API
 grant := twilio.NewConversationGrant(configurationProfileID)
 token.AddGrant(grant)
+
+// grant token access to video API
+grant := twiliogo.NewVideoGrant(room)
+token.AddGrant(grant)
 ```
 Then transform token to JWT format for client side usages.
 ```go

--- a/grant.go
+++ b/grant.go
@@ -33,6 +33,30 @@ func (g *conversationGrant) Payload() interface{} {
 	}
 }
 
+// NewVideoGrant creates a new video grant for twilio video conversation service.
+func NewVideoGrant(room string) Grant {
+	return &videoGrant{room: room}
+}
+
+// twilio video grant
+type videoGrant struct {
+	room string
+}
+
+// Key implements Grant interface.
+func (g *videoGrant) Key() string {
+	return "video"
+}
+
+// Payload implements Grant interface.
+func (g *videoGrant) Payload() interface{} {
+	return struct {
+		Room string `json:"room,omitempty"`
+	}{
+		Room: g.room,
+	}
+}
+
 // NewIPMessagingGrant creates a new permission for twilio ip messaging service.
 func NewIPMessagingGrant(serviceSid, endpointID, deploymentRoleSid, pushCredentialSid string) Grant {
 	return &ipMessagingGrant{


### PR DESCRIPTION
Configuration Profiles have been deprecated. This adds the Video Grant to create access tokens for the video chat service.

I'm not 100% sure if this is correct, but it is working for my app. I copied the python implementation:
https://github.com/twilio/twilio-python/blob/master/twilio/jwt/access_token/grants.py#L126